### PR TITLE
Added page.title to header

### DIFF
--- a/test.commotion/_includes/header.html
+++ b/test.commotion/_includes/header.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{{ site.name }}</title>
+    <title>{{ page.title }} | {{ site.name }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ site.description }}">
 


### PR DESCRIPTION
Browser title now takes the format:  page title | site title
Test by checking out branch issue-67 and building jekyll site locally.
Addresses: https://github.com/opentechinstitute/commotion-docs/issues/67
