### PR TITLE
Updated osx and ios developer resources

### DIFF
--- a/commotionwireless.net/developer/resources/commotion-mac/index.md
+++ b/commotionwireless.net/developer/resources/commotion-mac/index.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Commotion-Mac Developer Resources
+site_section: developers
+sub_section: devresources
+categories: 
+created: 2014-03-25
+post_author: areynold
+lang: en
+---
+
+<h2>Overview</h2>
+<p>Commotion is currently in a pure proof-of-concept state for Mac OS X and iOS devices. 
+The <a href="https://github.com/opentechinstitute/commotion-meshbook">Commotion-Meshbook</a> and 
+<a href="https://github.com/opentechinstitute/commotion-ios">Commotion-iOS</a> apps are simply a GUI wrappers for basic OLSRD and is
+not compatible with Commotion-Router 1.1.</p>
+
+<p>Commotion-Meshbook and Commotion-iOS developers should use the 
+<a href="https://wiki.commotionwireless.net/doku.php?id=commotion_architecture:commotion_client_architecture">Commotion Client Architecture</a> document
+as a guide for porting commotion.</p>
+
+<h2>Source Code</h2>
+<ul>
+  <li><a href="https://github.com/opentechinstitute/commotion-meshbook/">https://github.com/opentechinstitute/commotion-meshbook</a></li>
+  <li><a href="https://github.com/opentechinstitute/commotion-ios/">https://github.com/opentechinstitute/commotion-ios</a></li>
+</ul>
+
+<h2>Build Environment</h2>
+<p>See <a href="https://wiki.commotionwireless.net/doku.php?id=development_resources:macos:osx-dev-environment">OS X Development Environment</a></p>

--- a/commotionwireless.net/developer/resources/index.md
+++ b/commotionwireless.net/developer/resources/index.md
@@ -17,7 +17,7 @@ lang: en
 	<li><a href="commotion-android/">Commotion-Android app development guide</a></li>
 	<li><a href="https://wiki.commotionwireless.net/doku.php?id=commotion_architecture:commotion_client_architecture">Linux app development guide</a></li>
 	<li><a href="https://wiki.commotionwireless.net/doku.php?id=commotion_architecture:commotion_client_architecture">Windows app development guide</a></li>
-	<li><a href="https://wiki.commotionwireless.net/doku.php?id=commotion_architecture:commotion_client_architecture">Mac OS X app development guide</a></li>
+	<li><a href="commotion-mac/">Mac OS X and iOS app development guide</a></li>
 	<li><a href="https://wiki.commotionwireless.net/doku.php?id=general_openbts_notes">Open GSM development guide</a></li>
 </ul>
 


### PR DESCRIPTION
Adds more robust stubs for osx and ios developer resources, including links to draft notes on setting up the dev environment needed to port commotion-client to apple products
