### PR TITLE
Add space between doxygen class icon and class

### DIFF
--- a/commotionwireless.net/css/commotion-doxygen.css
+++ b/commotionwireless.net/css/commotion-doxygen.css
@@ -343,3 +343,7 @@ div#doxygen table.memberdecls td.memSeparator {
 div#doxygen table.memberdecls td.memItemLeft {
   padding: 0.25em 1em 0.25em 0;
 }
+
+.entry .icon {
+  padding-right: 10px;
+}


### PR DESCRIPTION
The icon spacing on https://commotionwireless.net/developer/api/commotiond/html/annotated.html makes the class list hard to read. This css tweak adds a bit of space between the icon and class name.

To test:
1. Load the doxygen-icons branch in jekyll.
2. Go to /developer/api/commotiond/html/annotated.html
3. The class names should read "C  __class_name", not "C__class_name".
