### PR TITLE
Menu width adjustments - small CSS change

### DIFF
--- a/commotionwireless.net/_includes/menu.html
+++ b/commotionwireless.net/_includes/menu.html
@@ -69,7 +69,7 @@
         <li role="presentation"><a role="menuitem" tabindex="-4" href="/developer/api" title="">API Reference</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-4" href="https://wiki.commotionwireless.net" title="">Wiki</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-4" href="https://github.com/organizations/opentechinstitute/dashboard/issues/repos?direction=desc&amp;state=open" title="">Issue Tracker</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="/developer/hig/introduction">Human Interface Guidelines</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-4" href="/developer/hig/introduction">Human Interface Guide</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-4" href="/jobs" title="Read and submit bids for open RFPs on the Commotion Wireless project.">Requests for Proposals</a></li>
       </ul>
     </li>

--- a/commotionwireless.net/css/commotion.css
+++ b/commotionwireless.net/css/commotion.css
@@ -57,7 +57,9 @@ div#logo img {
 /* top nav */
 div#navbar {
   padding-left: 300px;
-  margin-bottom: 75px;
+  margin-bottom: 0px;
+  min-height: 110px;
+  margin-right: 50px;
 }
 div#navbar ul > li a {
   border-bottom: 3px solid;


### PR DESCRIPTION
At narrow browser widths, the old CSS would cause the black bar to "bounce down" and things to wrap at strange points. Now things will wrap properly.

@natmey @critzo please take a look and merge when ready!
