### PR TITLE
Documentation menu - CCK replaced by "Community Wireless Guide"

### DIFF
--- a/commotionwireless.net/_includes/menu.html
+++ b/commotionwireless.net/_includes/menu.html
@@ -29,7 +29,7 @@
         <li role="presentation"><a role="menuitem" tabindex="-2" href="/docs/get-involved">Get Involved</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-2" href="/docs/supported-devices">Supported Devices</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-2" href="/docs/guides-howtos">Guides and How-Tos</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-2" href="/docs/cck">Commotion Construction Kit</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-2" href="/docs/cck">Community Wireless Guide</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-2" href="/docs/localization">Commotion Localization</a></li>
       </ul>
     </li>
@@ -52,11 +52,11 @@
         <b class="caret"></b>
       </a>
       <ul id="organizersMenu" class="dropdown-menu" aria-labelledby="organizersMenu" role="menu">
-        <li role="presentation"><a role="menuitem" tabindex="-3" href="/docs/cck/" title="Info for community organizers">Introduction</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-3" href="/docs/cck/planning" title="Activities for participatory planning">Planning</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-3" href="/docs/cck/installing-configuring" title="Commotion installation guides">Installing + Configuring</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-3" href="/docs/cck/building-mounting" title="How to install on rooftops">Building + Mounting</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-3" href="/docs/cck/networking" title="Learn more about networking">Networking</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-4" href="/docs/cck/" title="Info for community organizers">Introduction</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-4" href="/docs/cck/planning" title="Activities for participatory planning">Planning</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-4" href="/docs/cck/installing-configuring" title="Commotion installation guides">Installing + Configuring</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-4" href="/docs/cck/building-mounting" title="How to install on rooftops">Building + Mounting</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-4" href="/docs/cck/networking" title="Learn more about networking">Networking</a></li>
       </ul>
     </li>
     <li class="dropdown">
@@ -65,13 +65,13 @@
         <b class="caret"></b>
       </a>
       <ul id="developersMenu" class="dropdown-menu" aria-labelledby="developersMenu" role="menu">
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="/developer/resources" title="">Developer Resources</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="https://github.com/opentechinstitute" title="">Source Code</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="/developer/api" title="">API Reference</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="https://wiki.commotionwireless.net" title="">Wiki</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="https://github.com/organizations/opentechinstitute/dashboard/issues/repos?direction=desc&amp;state=open" title="">Issue Tracker</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="/developer/hig/introduction">Human Interface Guide</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-4" href="/jobs" title="Read and submit bids for open RFPs on the Commotion Wireless project.">Requests for Proposals</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="/developer/resources" title="">Developer Resources</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="https://github.com/opentechinstitute" title="">Source Code</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="/developer/api" title="">API Reference</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="https://wiki.commotionwireless.net" title="">Wiki</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="https://github.com/organizations/opentechinstitute/dashboard/issues/repos?direction=desc&amp;state=open" title="">Issue Tracker</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="/developer/hig/introduction">Human Interface Guide</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-5" href="/jobs" title="Read and submit bids for open RFPs on the Commotion Wireless project.">Requests for Proposals</a></li>
       </ul>
     </li>
   </ul>

--- a/commotionwireless.net/docs/cck/index.md
+++ b/commotionwireless.net/docs/cck/index.md
@@ -9,13 +9,13 @@ changed: 2014-03-04
 post_author: critzo
 lang: en
 ---
-  <p>The Commotion Construction Kit is a set of documentation tools that the Open Technology Institute has used in trainings around the world and at home. It is a “do it ourselves” guide to building wireless mesh networks.</p>
+<p>The Commotion Construction Kit is a set of documentation tools that the Open Technology Institute has used in workshops around the world and at home. It is a “do it ourselves” guide to building community wireless networks.</p>
 
 <div><span style="padding:10px;background-color:Gray;font-size:1em;display:block;"><img alt="" class="noscale" height="10" src="/files/styles/large/public/arrow_wht.png" style="vertical-align:middle;margin-right:10px;" width="29" /><a href="https://www.transifex.com/projects/p/commotion-documentation/" style="color:white;target:new tab front;">HELP US TRANSLATE THE COMMOTION CONSTRUCTION KIT</a></span></div>
 
 <p><img alt="Commotion Construction Kit promo image" src="/files/styles/large/public/CCK_general_intro.png" /></p>
 
-<p>You will be able to use them on your own or to work with a group of people. There is no one right way to move through them. You will find tools to help you learn the software and build and mount the hardware, as well as tools to help you organize with others in your neighborhood to plan, build, and promote a network. The modules are designed to be used by individuals or groups for self-guided learning or to teach workshops or trainings. Start to explore anywhere and let us know how it goes for you.</p>
+<p>You can use them on your own or to work with a group of people. There is no one right way to move through the activities. You will find tools to help you learn the software and build and mount the hardware, as well as tools to help you organize with others in your neighborhood to plan, build, and promote a network. The modules are designed to be used by individuals or groups for self-guided learning or to teach workshops or trainings. Start to explore anywhere and let us know how it goes for you.</p>
 
 <p>Like the Commotion software, these materials are open source, which means development on them continues and community involvement is critical. This first wave of modules represents a work in progress. The current set of modules are briefly described below.</p>
 


### PR DESCRIPTION
Small changes to menu include and CCK landing page to reflect change. Per issue #219 .
