### PR TITLE
Downcase tag_url to fix 404 of upcase tags

### DIFF
--- a/commotionwireless.net/_plugins/tag_list.rb
+++ b/commotionwireless.net/_plugins/tag_list.rb
@@ -13,7 +13,7 @@ module Jekyll
       html = ""
       tags = context.registers[:site].tags.keys
       tags.sort.each do |tag|
-	tag_url = tag.gsub(' ','-')
+	tag_url = tag.gsub(' ','-').downcase()
         posts_in_tag = context.registers[:site].tags[tag].size
         html << "<li class='list-group-item'><a href='/blog/tag/#{tag_url}'>#{tag} <span class='badge pull-right'>#{posts_in_tag}</span></a></li>\n"
       end


### PR DESCRIPTION
Not sure if this is truly required or if staging.commotionwireless.net was out of date. Still, fixes https://github.com/opentechinstitute/commotion-docs/issues/363.